### PR TITLE
FIX: Favicon 404's when not defined on siteconfig

### DIFF
--- a/templates/Includes/FavIcon.ss
+++ b/templates/Includes/FavIcon.ss
@@ -1,5 +1,5 @@
   <% if $SiteConfig.FavIcon %>
     <link rel="shortcut icon" href="$SiteConfig.FavIcon.Link" />
   <% else %>
-    <link rel="shortcut icon" href="favicon.ico" />
+    <link rel="shortcut icon" href="/favicon.ico" />
   <% end_if %>


### PR DESCRIPTION
When visiting any of the Security_*.ss templates, the favicon displays a 404 in the console because it's attempting to visit /Security/favicon.ico, which doesn't exist. This isn't a problem when a favicon is defined in the Site Settings of the CMS.